### PR TITLE
Refactors assembly definitions for better organization

### DIFF
--- a/Localisation/Editor/Panel/LocalisedTextMeshProEditor.cs
+++ b/Localisation/Editor/Panel/LocalisedTextMeshProEditor.cs
@@ -6,7 +6,7 @@ using UnityEditor.Localization;
 using UnityEngine;
 using UnityEngine.Localization.Tables;
 
-namespace Localisation
+namespace Localisation.Editor
 {
     /// <summary>
     /// Custom inspector for localised text mesh pros

--- a/Localisation/Editor/dev.goreng.localisation.editor.asmdef
+++ b/Localisation/Editor/dev.goreng.localisation.editor.asmdef
@@ -1,0 +1,22 @@
+{
+    "name": "dev.goreng.localisation.editor",
+    "rootNamespace": "Localisation.Editor",
+    "references": [
+        "GUID:6546d7765b4165b40850b3667f981c26",
+        "GUID:2e77701fe0ceda44fb763f03ee704c37",
+        "GUID:be76e95d0b6dc4369812af2934ae8a2d",
+        "GUID:eec0964c48f6f4e40bc3ec2257ccf8c5",
+        "GUID:6055be8ebefd69e48b49212b09b47b2f"
+    ],
+    "includePlatforms": [
+        "Editor"
+    ],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": false,
+    "precompiledReferences": [],
+    "autoReferenced": true,
+    "defineConstraints": [],
+    "versionDefines": [],
+    "noEngineReferences": false
+}

--- a/Localisation/Editor/dev.goreng.localisation.editor.asmdef.meta
+++ b/Localisation/Editor/dev.goreng.localisation.editor.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 25b2071c3ded99942964fc5884ab60b4
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Localisation/Plugin/POEditor/Api/PoEditorApi.cs
+++ b/Localisation/Plugin/POEditor/Api/PoEditorApi.cs
@@ -9,7 +9,7 @@ using Newtonsoft.Json;
 using UnityEngine;
 using UnityEngine.Networking;
 
-namespace Localisation.Plugin.POEditor.API
+namespace Localisation
 {
     /// <summary>
     /// Client for interacting with the POEditor API.

--- a/Localisation/Plugin/POEditor/Editor/Window/PoEditorWindow.cs
+++ b/Localisation/Plugin/POEditor/Editor/Window/PoEditorWindow.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using Localisation.Plugin.POEditor.API;
 using Newtonsoft.Json;
 using UnityEditor;
 using UnityEditor.Localization;
@@ -9,10 +8,9 @@ using UnityEditor.Localization.Plugins.XLIFF;
 using UnityEngine;
 using UnityEngine.Localization.Settings;
 using UnityEngine.Localization.Tables;
-using UnityEngine.Networking;
 using UnityEngine.UIElements;
 
-namespace DesignSystem.Editor.Window
+namespace Localisation.Editor.Plugin
 {
     public class PoEditorWindow: EditorWindow
     {

--- a/Localisation/Plugin/POEditor/Editor/dev.goreng.localisation.plugin.asmdef
+++ b/Localisation/Plugin/POEditor/Editor/dev.goreng.localisation.plugin.asmdef
@@ -1,13 +1,17 @@
 {
-    "name": "dev.goreng.localisation",
-    "rootNamespace": "Localisation",
+    "name": "dev.goreng.localisation.plugin",
+    "rootNamespace": "Localisation.Editor.Plugin",
     "references": [
+        "GUID:6546d7765b4165b40850b3667f981c26",
+        "GUID:2e77701fe0ceda44fb763f03ee704c37",
+        "GUID:25b2071c3ded99942964fc5884ab60b4",
         "GUID:eec0964c48f6f4e40bc3ec2257ccf8c5",
-        "GUID:6055be8ebefd69e48b49212b09b47b2f",
-        "GUID:7ceb27f3997bff847ad2c134b0ae9986",
+        "GUID:be76e95d0b6dc4369812af2934ae8a2d",
         "GUID:84651a3751eca9349aac36a66bba901b"
     ],
-    "includePlatforms": [],
+    "includePlatforms": [
+        "Editor"
+    ],
     "excludePlatforms": [],
     "allowUnsafeCode": false,
     "overrideReferences": false,

--- a/Localisation/Plugin/POEditor/Editor/dev.goreng.localisation.plugin.asmdef.meta
+++ b/Localisation/Plugin/POEditor/Editor/dev.goreng.localisation.plugin.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 74c36d1eede5f64499e3979049e357b6
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Localisation/Plugin/POEditor/Models/ExportParameters.cs
+++ b/Localisation/Plugin/POEditor/Models/ExportParameters.cs
@@ -1,4 +1,4 @@
-namespace UnityEngine.Networking
+namespace Localisation
 {
     public class PoEditorExportParameters
     {

--- a/Localisation/Plugin/POEditor/Models/ExportResponse.cs
+++ b/Localisation/Plugin/POEditor/Models/ExportResponse.cs
@@ -1,4 +1,4 @@
-namespace UnityEngine.Networking
+namespace Localisation
 {
     public struct PoEditorResponse
     {

--- a/Localisation/Plugin/POEditor/Models/PoEditorApiConfiguration.cs
+++ b/Localisation/Plugin/POEditor/Models/PoEditorApiConfiguration.cs
@@ -1,6 +1,6 @@
-namespace UnityEngine.Networking
+namespace Localisation
 {
-    internal class PoEditorApiConfiguration
+    public class PoEditorApiConfiguration
     {
         public string apiKey;
 

--- a/Localisation/Plugin/POEditor/Models/PoEditorProject.cs
+++ b/Localisation/Plugin/POEditor/Models/PoEditorProject.cs
@@ -1,4 +1,4 @@
-﻿namespace UnityEngine.Networking
+﻿namespace Localisation
 {
     public struct PoEditorProject
     {

--- a/Localisation/Plugin/POEditor/Models/PoEditorProjectResponse.cs
+++ b/Localisation/Plugin/POEditor/Models/PoEditorProjectResponse.cs
@@ -1,6 +1,6 @@
 ﻿using System.Collections.Generic;
 
-namespace UnityEngine.Networking
+namespace Localisation
 {
     public class PoEditorProjectResponse
     {

--- a/Localisation/Plugin/POEditor/Models/PoeEditorToken.cs
+++ b/Localisation/Plugin/POEditor/Models/PoeEditorToken.cs
@@ -1,4 +1,4 @@
-﻿namespace UnityEngine.Networking
+﻿namespace Localisation
 {
     public struct PoeEditorToken
     {

--- a/Localisation/Plugin/POEditor/Models/Result.cs
+++ b/Localisation/Plugin/POEditor/Models/Result.cs
@@ -2,7 +2,7 @@
 using System;
 
 
-namespace UnityEngine.Networking
+namespace Localisation
 {
     public class Result<T, E> where E : Exception
     {


### PR DESCRIPTION
This change improves the project's structure by:

- Creating a new assembly definition for Editor-specific code.
- Moving Editor-related scripts and dependencies into the new assembly.
- Adjusting assembly references to reflect the new structure, ensuring correct dependency resolution between runtime and editor code.

This change enhances modularity and improves compile times for the core runtime.