### PR TITLE
Update PoEditorWindow.cs

### DIFF
--- a/Localisation/Plugin/POEditor/Editor/Window/PoEditorWindow.cs
+++ b/Localisation/Plugin/POEditor/Editor/Window/PoEditorWindow.cs
@@ -213,7 +213,7 @@ namespace Localisation.Editor.Plugin
                     return;
                 }
 
-                collection.ClearAllEntries();
+                table.Clear();
                     
                 _actionLabel.text = "Importing strings into table";
                 Xliff.ImportFileIntoTable(path, table);


### PR DESCRIPTION
Replaced collection.ClearAllEntries() with table.Clear() to ensure that only the selected language's StringTable is cleared prior to import, preserving translations in other locales.