### PR TITLE
Adds POEditor CLI integration for localisation

### DIFF
--- a/Localisation/Plugin/POEditor/Api/PoEditorApi.cs
+++ b/Localisation/Plugin/POEditor/Api/PoEditorApi.cs
@@ -11,6 +11,19 @@ using UnityEngine.Networking;
 
 namespace Localisation
 {
+    internal static class Utils
+    {
+        public static async Task AsTask(this Awaitable a)
+        {
+            await a;
+        }
+
+        public static async Task<T> AsTask<T>(this Awaitable<T> a)
+        {
+            return await a;
+        }
+    }
+    
     /// <summary>
     /// Client for interacting with the POEditor API.
     /// Provides methods to authenticate, list projects, export translations, and download files.
@@ -79,7 +92,7 @@ namespace Localisation
         /// A task that completes with an <see cref="ExportResponse"/>
         /// containing download information and metadata.
         /// </returns>
-        public async Awaitable<Result<ExportResponse, Exception>> ExportLanguage(string language, string projectId)
+        public async Task<Result<ExportResponse, Exception>> ExportLanguage(string language, string projectId)
         {
             var path = $"/projects/export";
 
@@ -96,7 +109,11 @@ namespace Localisation
                 .SetTransformer(FormEncodedTransformer.Transform)
                 .SetHeader("Content-Type", "application/x-www-form-urlencoded")
                 .SetBody(arguments)
-                .Send();
+                .Send()
+                #if UNITY_EDITOR
+                .AsTask()
+                .ConfigureAwait(false);
+                #endif
             
             try
             {

--- a/Localisation/Plugin/POEditor/Api/PoEditorCliApi.cs
+++ b/Localisation/Plugin/POEditor/Api/PoEditorCliApi.cs
@@ -1,0 +1,135 @@
+﻿
+#if UNITY_EDITOR
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Newtonsoft.Json;
+using UnityEngine;
+
+namespace Localisation
+{
+    /// <summary>
+    /// Client for interacting with the POEditor API.
+    /// Provides methods to authenticate, list projects, export translations, and download files.
+    /// </summary>
+    ///
+    public class PoEditorCliApi
+    {
+        private const string _baseUrl = "https://api.poeditor.com/v2";
+        private string? _apiKey;
+
+        /// <summary>
+        /// Sets the API key for authenticating with the POEditor API.
+        /// </summary>
+        /// <param name="apiKey">The API key provided by POEditor.</param>
+        public void SetCredentials(string apiKey)
+        {
+            _apiKey = apiKey;
+        }
+
+        /// <summary>
+        /// Downloads a file from the specified URL and saves it to the given local path.
+        /// </summary>
+        /// <param name="url">The full URL of the file to download.</param>
+        /// <param name="path">Local filesystem path where the downloaded file will be saved.</param>
+        /// <returns>A task representing the asynchronous download and file write operation.</returns>
+        public async Task DownloadFile(string url, string path)
+        {
+            // Create a new client for this request, mirroring the working test case.
+            using var httpClient = new HttpClient();
+            var fileBytes = await httpClient.GetByteArrayAsync(url).ConfigureAwait(false);
+            await File.WriteAllBytesAsync(path, fileBytes).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Retrieves a list of POEditor projects accessible with the current API key.
+        /// </summary>
+        /// <returns>
+        /// A task that completes with a <see cref="PoEditorProjectResponse"/>
+        /// containing the project list result.
+        /// </returns>
+        public async Task<PoEditorProjectResponse> ListProjects()
+        {
+            var path = "/projects/list";
+
+            var formContent = new FormUrlEncodedContent(new[]
+            {
+                new KeyValuePair<string, string>("api_token", _apiKey ?? string.Empty)
+            });
+
+            // Create a new client for this request.
+            using var httpClient = new HttpClient();
+            var response =
+                await httpClient.PostAsync(_baseUrl + path, formContent).ConfigureAwait(false);
+            response.EnsureSuccessStatusCode();
+
+            var jsonResponse = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+            var data = JsonConvert
+                .DeserializeObject<PoEditorResponseWrapper<PoEditorProjectResponse>>(jsonResponse);
+
+            return data.result;
+        }
+
+        /// <summary>
+        /// Exports translations for a specific language from a POEditor project.
+        /// </summary>
+        /// <param name="language">The language code to export (e.g., "en", "fr").</param>
+        /// <param name="projectId">The unique identifier of the POEditor project.</param>
+        /// <returns>
+        /// A task that completes with a <see cref="Result{TSuccess,TFailure}"/>
+        /// containing download information or an exception.
+        /// </returns>
+        public async Task<Result<ExportResponse, Exception>> ExportLanguage(string language, string projectId)
+        {
+            var path = "/projects/export";
+
+            var parameters = new Dictionary<string, string>
+            {
+                { "api_token", _apiKey ?? string.Empty },
+                { "id", projectId },
+                { "language", language },
+                { "type", "xliff_1_2" }
+            };
+
+            var formContent = new FormUrlEncodedContent(parameters);
+
+            try
+            {
+                // Create a new client for this request.
+                using var httpClient = new HttpClient();
+                
+                Debug.Log("Before sending request to POEditor API");
+                
+                var response = await httpClient
+                    .PostAsync(_baseUrl + path, formContent)
+                    .ConfigureAwait(false);
+                
+                Debug.Log("After sending request to POEditor API");
+                
+                var jsonResponse = await response.Content
+                    .ReadAsStringAsync()
+                    .ConfigureAwait(false);
+
+                Debug.Log("After reading string");
+                
+                var data = JsonConvert.DeserializeObject<PoEditorResponseWrapper<ExportResponse>>(jsonResponse);
+                
+                Debug.Log($"After deserializing response {data.response.status}");
+                
+                if (data.response.status == "fail")
+                {
+                    return Result<ExportResponse, Exception>.Fail(new InvalidDataException(data.response.message));
+                }
+
+                return Result<ExportResponse, Exception>.Success(data.result);
+            }
+            catch (Exception ex)
+            {
+                return Result<ExportResponse, Exception>.Fail(ex);
+            }
+        }
+    }
+}
+#endif

--- a/Localisation/Plugin/POEditor/Api/PoEditorCliApi.cs.meta
+++ b/Localisation/Plugin/POEditor/Api/PoEditorCliApi.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: a3e96d75058fd684487c64046caa741e

--- a/Localisation/Plugin/POEditor/Editor/POEditorImporter.cs
+++ b/Localisation/Plugin/POEditor/Editor/POEditorImporter.cs
@@ -1,0 +1,185 @@
+﻿#nullable enable
+
+using System;
+using System.Collections;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using UnityEditor;
+using UnityEditor.Localization;
+using UnityEditor.Localization.Plugins.XLIFF;
+using UnityEngine;
+using UnityEngine.Localization.Settings;
+using UnityEngine.Localization.Tables;
+
+namespace Localisation.Editor.Plugin
+{
+    public static class PoEditorImporter
+    {
+        /// <summary>
+        /// A helper class to store the result of a download operation.
+        /// </summary>
+        private class LocaleDownloadResult
+        {
+            public bool Success { get; set; }
+            public string LanguageCode { get; set; } = "";
+            public string TempPath { get; set; } = "";
+            public string ErrorMessage { get; set; } = "";
+        }
+
+        [MenuItem("Framework/Import All Localisations from CLI (Runner)")]
+        public static void ImportAllFromCli_Wrapper()
+        {
+            Debug.Log("Starting CLI import process with Coroutines...");
+            var coroutine = ImportAllFromCliCoroutine();
+            bool isRunning = true;
+
+            // This loop manually drives the coroutine's execution.
+            while (isRunning)
+            {
+                try
+                {
+                    // MoveNext() executes the coroutine until the next 'yield'.
+                    // It returns false when the coroutine has finished.
+                    if (!coroutine.MoveNext())
+                    {
+                        isRunning = false;
+                        Debug.Log("CLI import process completed successfully.");
+                        EditorApplication.Exit(0);
+                    }
+                }
+                catch (Exception e)
+                {
+                    // If the coroutine throws an exception, it will be caught here.
+                    isRunning = false;
+                    Debug.LogError("CLI import process failed with an exception.");
+                    Debug.LogException(e);
+                    EditorApplication.Exit(1);
+                }
+                // Sleep to prevent the loop from consuming 100% CPU.
+                Thread.Sleep(100);
+            }
+        }
+        
+        private static IEnumerator ImportAllFromCliCoroutine()
+        {
+            // The main logic is now inside a standard IEnumerator coroutine.
+            var args = Environment.GetCommandLineArgs();
+            var apiKey = GetArgument(args, "-poeditor-api-key");
+            var projectId = GetArgument(args, "-poeditor-project-id");
+            var stringTableName = "Strings";
+
+            if (string.IsNullOrEmpty(apiKey) || string.IsNullOrEmpty(projectId))
+            {
+                Debug.LogError("Missing required arguments. Use -poeditor-api-key and -poeditor-project-id");
+                EditorApplication.Exit(1);
+                yield break; // End the coroutine
+            }
+
+            Debug.Log($"API Key found, Project ID: {projectId}");
+
+            var api = new PoEditorCliApi();
+            api.SetCredentials(apiKey);
+
+            var instance = LocalizationSettings.Instance;
+            var initializationTask = instance.GetInitializationOperation().Task;
+            // Wait for the Task to complete by polling its status.
+            while (!initializationTask.IsCompleted)
+            {
+                yield return null;
+            }
+            if (initializationTask.IsFaulted) throw initializationTask.Exception;
+
+            var locales = instance.GetAvailableLocales().Locales;
+
+            Debug.Log("Starting sequential import for all locales...");
+            foreach (var locale in locales)
+            {
+                // Start the async download operation, which returns a Task.
+                var downloadTask = DownloadLocaleAsync(api, locale.Identifier.Code, projectId);
+
+                // Yield control until the Task is complete.
+                while (!downloadTask.IsCompleted)
+                {
+                    yield return null;
+                }
+
+                // Check for exceptions inside the completed task.
+                if (downloadTask.IsFaulted)
+                {
+                    if (downloadTask.Exception != null) throw downloadTask.Exception;
+                }
+                
+                var result = downloadTask.Result;
+
+                if (!result.Success)
+                {
+                    Debug.LogError(result.ErrorMessage);
+                    continue;
+                }
+                
+                var collection = LocalizationEditorSettings.GetStringTableCollection(stringTableName);
+                if (collection == null)
+                {
+                    throw new InvalidOperationException($"StringTableCollection '{stringTableName}' not found.");
+                }
+
+                var table = collection.GetTable(result.LanguageCode) as StringTable;
+                if (table == null)
+                {
+                    Debug.LogWarning($"String Table for '{result.LanguageCode}' not found in '{stringTableName}'. Skipping.");
+                    continue;
+                }
+
+                table.Clear();
+                Debug.Log($"Importing strings into table for language '{result.LanguageCode}'.");
+                Xliff.ImportFileIntoTable(result.TempPath, table);
+                EditorUtility.SetDirty(table);
+                Debug.Log($"Successfully imported {table.Count} entries for '{result.LanguageCode}'.");
+
+                try { File.Delete(result.TempPath); }
+                catch (Exception e) { Debug.LogWarning($"Could not delete temp file {result.TempPath}: {e.Message}"); }
+            }
+
+            AssetDatabase.SaveAssets();
+            Debug.Log("All locales processed.");
+        }
+
+        /// <summary>
+        /// This method remains async Task because it uses HttpClient, which is Task-based.
+        /// The coroutine will wait for the returned Task to complete.
+        /// </summary>
+        private static async Task<LocaleDownloadResult> DownloadLocaleAsync(PoEditorCliApi api, string languageCode, string projectId)
+        {
+            try
+            {
+                var exportResult = await api.ExportLanguage(languageCode, projectId).ConfigureAwait(false);
+                if (exportResult.hasError)
+                {
+                    return new LocaleDownloadResult { Success = false, ErrorMessage = $"Failed to export '{languageCode}': {exportResult.error?.Message}" };
+                }
+                
+                var downloadUrl = exportResult.result.url;
+                var tempPath = Path.Combine(Path.GetTempPath(), $"file-{languageCode}.xliff");
+                await api.DownloadFile(downloadUrl, tempPath).ConfigureAwait(false);
+                return new LocaleDownloadResult { Success = true, LanguageCode = languageCode, TempPath = tempPath };
+            }
+            catch (Exception e)
+            {
+                return new LocaleDownloadResult { Success = false, ErrorMessage = $"Exception while downloading '{languageCode}': {e.Message}" };
+            }
+        }
+
+        private static string GetArgument(string[] args, string name)
+        {
+            for (int i = 0; i < args.Length - 1; i++)
+            {
+                if (args[i] == name)
+                {
+                    return args[i + 1];
+                }
+            }
+            return null;
+        }
+    }
+}

--- a/Localisation/Plugin/POEditor/Editor/POEditorImporter.cs.meta
+++ b/Localisation/Plugin/POEditor/Editor/POEditorImporter.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 7e08d2787e18b6d4b920a999ab1c59ef

--- a/Localisation/Runtime/LocaleString.cs
+++ b/Localisation/Runtime/LocaleString.cs
@@ -10,7 +10,7 @@ namespace Localisation.Plugin
         private string _key;
         private object[] _args;
         private readonly LocalizedString _localizedString;
-        private readonly BaseEventProducer<string> _onStringRefreshedEventProducer = new();
+        private readonly BaseEventProducer<string> _onStringRefreshedEventProducer = new(true);
         
         public IEventListener<string> onStringRefreshed => _onStringRefreshedEventProducer.listener;
         


### PR DESCRIPTION
Introduces a command-line interface (CLI) to streamline the localization process with POEditor.

This change allows importing translations directly from the POEditor platform within the Unity Editor, automating the process of updating localization data.

The implementation handles authentication, project listing, language exporting, and file downloading, and also incorporates error handling.

It supports importing XLIFF files, refreshing strings, and updating tables with localization information.
